### PR TITLE
insere a criação de arquivo compactado com todos os serviços

### DIFF
--- a/scripts/check
+++ b/scripts/check
@@ -27,3 +27,6 @@ fi
 for xml in $CARTAS_DIR/*.xml; do
   xmllint --schema $SCHEMA --noout "$xml"
 done
+
+zip $CARTAS_DIR/servicos.zip $CARTAS_DIR/*.xml
+


### PR DESCRIPTION
Uma possível solução para  #48 é gerar um arquivo zip por script. No caso, coloquei no mesmo script que roda o xmllint, mas poderia ser em outro script.

Depois disso ainda restaria a tarefa de servir o arquivo para a web no servidor.
